### PR TITLE
chore: set default `min_confirmations` in config.yml.example

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -276,7 +276,7 @@ testnet:
     delay_ms_per_batch: 5000
     gas_remain_x_threshold: 2.0
   min_confirmations:
-    ethereum: 2
+    ethereum-2: 2
     binance: 2
     polygon: 5
     avalanche: 1

--- a/config.yml.example
+++ b/config.yml.example
@@ -10,18 +10,18 @@ mainnet:
     delay_ms_per_batch: 5000
     gas_remain_x_threshold: 2.0
   min_confirmations:
-    ethereum: 1
-    binance: 1
-    polygon: 1
+    ethereum: 2
+    binance: 2
+    polygon: 5
     avalanche: 1
     fantom: 1
-    moonbeam: 1
-    aurora: 1
-    arbitrum: 1
-    optimism: 1
+    moonbeam: 2
+    aurora: 2
+    arbitrum: 2
+    optimism: 2
     celo: 1
     kava: 1
-    default: 1
+    default: 2
   chains:
     ethereum:
       contract_address: ""
@@ -276,18 +276,18 @@ testnet:
     delay_ms_per_batch: 5000
     gas_remain_x_threshold: 2.0
   min_confirmations:
-    ethereum-2: 1
-    binance: 1
-    polygon: 1
+    ethereum: 2
+    binance: 2
+    polygon: 5
     avalanche: 1
     fantom: 1
-    moonbeam: 1
-    aurora: 1
-    arbitrum: 1
-    optimism: 1
+    moonbeam: 2
+    aurora: 2
+    arbitrum: 2
+    optimism: 2
     celo: 1
     kava: 1
-    default: 1
+    default: 2
   chains:
     ethereum-2:
       contract_address: ""

--- a/services/forecaller/process/forecall.js
+++ b/services/forecaller/process/forecall.js
@@ -328,7 +328,7 @@ const forecall = async (
       const _confirmations =
         min_confirmations?.[sourceChain] ||
         min_confirmations?.default ||
-        1;
+        2;
 
       if (confirmations < _confirmations) {
         // update receipt


### PR DESCRIPTION
```
min_confirmations:
    ethereum: 2
    binance: 2
    polygon: 5
    avalanche: 1
    fantom: 1
    moonbeam: 2
    aurora: 2
    arbitrum: 2
    optimism: 2
    celo: 1
    kava: 1
    default: 2 //(for other chains)
  ```